### PR TITLE
fix: automatically clear old numeric userId from localStorage

### DIFF
--- a/docs/troubleshooting-uuid-issue.md
+++ b/docs/troubleshooting-uuid-issue.md
@@ -1,0 +1,76 @@
+# UUID表示問題のトラブルシューティング
+
+## 問題
+デプロイ後にmypageのURLパスがUUIDではなく数値（例: `4`）で表示される
+
+## 原因の可能性
+
+### 1. localStorageに古い数値のuserIdが残っている（最も可能性が高い）
+- ブラウザのlocalStorageに古いInteger型のuserId（例: `4`）が保存されている
+- ログインし直しても、既存のユーザーがfirebase_uidで見つかった場合、古いIDが返される可能性がある
+
+### 2. バックエンドのデプロイが完了していない
+- バックエンドがまだUUID対応のコードでデプロイされていない
+- `/me`エンドポイントがまだInteger型のIDを返している
+
+### 3. フロントエンドのデプロイが完了していない
+- フロントエンドがまだUUID対応のコードでデプロイされていない
+- 古いコードがNumber()変換を実行している
+
+## 解決方法
+
+### 方法1: localStorageをクリア（推奨）
+1. ブラウザの開発者ツールを開く（F12）
+2. Applicationタブ（Chrome）またはStorageタブ（Firefox）を開く
+3. Local Storageを選択
+4. サイトのドメインを選択
+5. `userId`キーを削除
+6. ページをリロードして再ログイン
+
+### 方法2: プログラムでlocalStorageをクリア
+```javascript
+// ブラウザのコンソールで実行
+localStorage.removeItem('userId');
+location.reload();
+```
+
+### 方法3: シークレットモードで確認
+- シークレットモードでアプリを開く
+- 新規ログインしてUUIDが正しく表示されるか確認
+
+## 確認方法
+
+### 1. localStorageの確認
+```javascript
+// ブラウザのコンソールで実行
+console.log('userId:', localStorage.getItem('userId'));
+console.log('型:', typeof localStorage.getItem('userId'));
+```
+
+### 2. /meエンドポイントの確認
+- ネットワークタブで`/me`エンドポイントのレスポンスを確認
+- `id`フィールドがUUID文字列（例: `9e9c8034-970a-4d52-8354-d08821f298f5`）になっているか確認
+
+### 3. バックエンドの確認
+- バックエンドのログで`/me`エンドポイントが呼ばれているか確認
+- 返される`id`の形式を確認
+
+## 根本的な解決策
+
+### フロントエンドにlocalStorageの検証を追加
+ログイン時にlocalStorageのuserIdが数値形式（古い形式）の場合は削除する：
+
+```typescript
+// login/page.tsx などに追加
+const oldUserId = localStorage.getItem('userId');
+if (oldUserId && !isNaN(Number(oldUserId))) {
+  // 古い数値形式のuserIdを削除
+  localStorage.removeItem('userId');
+}
+```
+
+## 注意事項
+- 既存のユーザーはマイグレーション済みでUUIDになっているはず
+- 新しいユーザーは自動的にUUIDが割り当てられる
+- 問題が続く場合は、バックエンドとフロントエンドのデプロイ状況を確認
+

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -16,6 +16,12 @@ export default function LoginPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
+      // 古い数値形式のuserIdを削除（UUID移行対応）
+      const oldUserId = localStorage.getItem('userId');
+      if (oldUserId && !isNaN(Number(oldUserId))) {
+        localStorage.removeItem('userId');
+      }
+      
       const cred = await signInWithEmailAndPassword(auth, email, password);
       if (cred.user) {
         try {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -20,7 +20,14 @@ export default function Home() {
     if (isAuthenticated) {
       try {
         const raw = localStorage.getItem('userId');
-        if (raw) { // UUID文字列として扱う（Number()変換を削除）
+        if (raw) {
+          // 古い数値形式のuserIdを削除（UUID移行対応）
+          if (!isNaN(Number(raw)) && raw.length < 10) {
+            localStorage.removeItem('userId');
+            router.push('/login');
+            return;
+          }
+          // UUID文字列として扱う
           router.push(`/mypage/${raw}`);
         } else {
           router.push('/login');

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -22,6 +22,12 @@ export default function SignupPage() {
         await updateProfile(cred.user, { displayName });
       }
       // サインアップ直後に /me を呼び、users テーブルに作成（なければ作成）し id を取得
+      // 古い数値形式のuserIdを削除（UUID移行対応）
+      const oldUserId = localStorage.getItem('userId');
+      if (oldUserId && !isNaN(Number(oldUserId))) {
+        localStorage.removeItem('userId');
+      }
+      
       try {
         const token = await getIdToken(cred.user!);
         const res = await api.get('/me', {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -12,7 +12,14 @@ const Header = () => {
   const goMyPage = () => {
     try {
       const raw = localStorage.getItem('userId');
-      if (raw) { // UUID文字列として扱う（Number()変換を削除）
+      if (raw) {
+        // 古い数値形式のuserIdを削除（UUID移行対応）
+        if (!isNaN(Number(raw)) && raw.length < 10) {
+          localStorage.removeItem('userId');
+          router.push('/login');
+          return;
+        }
+        // UUID文字列として扱う
         router.push(`/mypage/${raw}`);
         return;
       }


### PR DESCRIPTION
## Summary
This PR fixes the issue where old numeric userId values remain in localStorage after UUID migration, causing incorrect URL paths (e.g.,  instead of ).

## Problem
After deploying the UUID migration, users who had previously logged in with numeric user IDs (e.g., ) still have the old value in localStorage. This causes:
- Incorrect URL paths when navigating to mypage
- API calls with invalid user IDs
- User confusion

## Solution
Automatically detect and remove old numeric userId values from localStorage:
- **On login/signup**: Clear old numeric userId before storing new UUID
- **On mypage navigation**: Detect old numeric userId and redirect to login if found

## Changes
- : Clear old numeric userId before login
- : Clear old numeric userId before signup  
- : Detect and remove old numeric userId on mypage navigation
- : Detect and remove old numeric userId on mypage navigation
- Add troubleshooting documentation

## Testing
- [x] Old numeric userId is cleared on login
- [x] Old numeric userId is cleared on signup
- [x] Old numeric userId is detected on mypage navigation
- [x] UUID userId works correctly after cleanup

## Related
- Fixes UUID migration compatibility issue
- Improves user experience after database migration