### PR TITLE
fix: add user_id to Result type in API responses

### DIFF
--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -22,7 +22,12 @@ function App() {
                     const apiBase = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
                     const response = await axios.get(`${apiBase}/users/${selectedUserId}`);
                     console.log("API Response:", response.data);
-                    setUserResults(response.data.results);
+                    // APIレスポンスのresultsにuser_idが含まれていることを確認
+                    const results: Result[] = (response.data.results || []).map((result: any) => ({
+                        ...result,
+                        user_id: result.user_id || selectedUserId
+                    }))
+                    setUserResults(results);
                     setSelectedUserName(response.data.name);
                 } catch (error: unknown) {
                     console.error(error);

--- a/frontend/src/app/PhysicalTestResults.tsx
+++ b/frontend/src/app/PhysicalTestResults.tsx
@@ -123,12 +123,13 @@ function PhysicalTestResults({ userId }: PhysicalTestResultsProps) {
                     const response = await axios.get(`${apiBase}/user_results/${userId}`);
                     console.log("API Response (fetchUserResults):", response.data);
 
-                    // データを変換
-                    const convertedResults = response.data.map((result: Result) => {
+                    // データを変換（user_idを含める）
+                    const convertedResults = response.data.map((result: any) => {
                         console.log("Original Result:", result); // 変換前のデータを確認
 
                         return {
                             ...result,
+                            user_id: result.user_id || userId, // user_idを確実に含める
                             long_jump: result.long_jump_cm,
                             fifty_meter_run: result.fifty_meter_run_ms,
                             spider: result.spider_ms,

--- a/frontend/src/app/mypage/MyPageContent.tsx
+++ b/frontend/src/app/mypage/MyPageContent.tsx
@@ -9,7 +9,7 @@ import { mockInProgressTrainings, mockRecentTrainings, seedMyPageMocksToLocalSto
 
 type UserResult = {
   id: number;
-  user_id: number;
+  user_id: string; // UUID型に変更
   date: string;
   long_jump_cm: number;
   fifty_meter_run_ms: number;

--- a/frontend/src/app/test-results/page.tsx
+++ b/frontend/src/app/test-results/page.tsx
@@ -8,18 +8,9 @@ import UserForm from '../../components/UserForm'
 import UserList from '../../components/UserList'
 import ResultForm from '../../components/ResultForm'
 import ResultList from '../../components/ResultList'
+import { Result } from '@/types/Result'
 import axios from 'axios'
 import { useState } from 'react'
-
-interface Result {
-    id: number;
-    date: string;
-    long_jump_cm: number;
-    fifty_meter_run_ms: number;
-    spider_ms: number;
-    eight_shape_run_count: number;
-    ball_throw_cm: number;
-  }
 
 function TestResultsContent() {
   const isAuthenticated = useAuth()
@@ -49,7 +40,12 @@ function TestResultsContent() {
           axios.get(`${apiBase}/users/${userId}`),
           axios.get(`${apiBase}/user_results/${userId}`)
         ])
-        setUserResults(resultsResponse.data)
+        // APIレスポンスにuser_idが含まれていることを確認し、型を明示的に指定
+        const results: Result[] = resultsResponse.data.map((result: any) => ({
+          ...result,
+          user_id: result.user_id || userId // user_idが欠けている場合はuserIdを使用
+        }))
+        setUserResults(results)
         setSelectedUserName(userResponse.data.name)
       } catch (error) {
         console.error('データ取得に失敗しました:', error)


### PR DESCRIPTION
## Summary
This PR fixes the TypeScript build error where the `Result` type was missing the required `user_id` property when passed to the `ResultList` component.

## Problem
The build was failing with:
```
Type error: Type 'Result[] | null' is not assignable to type 'import("/vercel/path0/frontend/src/types/Result").Result[] | null'.
Property 'user_id' is missing in type 'Result' but required in type 'import("/vercel/path0/frontend/src/types/Result").Result'.
```

## Solution
- Removed duplicate `Result` interface from `test-results/page.tsx` and imported from `@/types/Result`
- Added explicit `user_id` mapping in API response handling
- Updated `UserResult` type in `MyPageContent.tsx` to use `string` (UUID) for `user_id`

## Changes
- `test-results/page.tsx`: Remove local Result interface, import from @/types/Result, add user_id to API response
- `App.tsx`: Add user_id to results array
- `PhysicalTestResults.tsx`: Add user_id to convertedResults
- `MyPageContent.tsx`: Update UserResult.user_id type from number to string (UUID)

## Testing
- [x] Build succeeds locally
- [x] TypeScript type checking passes
- [x] All Result types now include user_id field

## Related
- Fixes Vercel build error
- Ensures consistency with UUID migration