### PR TITLE
frontend: コアトレーニングページ追加の反映

### DIFF
--- a/frontend/src/app/core/[id]/page.tsx
+++ b/frontend/src/app/core/[id]/page.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Image from 'next/image';
+import { useParams, useRouter } from 'next/navigation';
+import { useFlexibilityCheck } from '@/hooks/useFlexibilityChecks';
+
+export default function CoreTrainingDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  // trainings API は共通なので、既存のフックを再利用
+  const { check: training, loading, error } = useFlexibilityCheck(id);
+  const router = useRouter();
+
+  if (loading) return <div className="p-4">読み込み中…</div>;
+  if (error) return <div className="p-4 text-red-500">{error}</div>;
+
+  if (!training) {
+    return (
+      <div className="p-4">
+        トレーニングが見つかりません。
+        <button
+          className="ml-2 text-blue-600 underline"
+          onClick={() => router.push('/core')}
+        >
+          一覧に戻る
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <button
+        className="mb-4 text-blue-600 underline"
+        onClick={() => router.push('/core')}
+      >
+        ← 体幹トレーニング一覧に戻る
+      </button>
+
+      <h1 className="mb-4 text-3xl font-bold">{training.title}</h1>
+
+      {training.image_path && (
+        <div className="relative w-full h-64 mb-4">
+          <Image
+            src={training.image_path}
+            alt={training.title}
+            fill
+            className="object-contain"
+          />
+        </div>
+      )}
+
+      <section className="mb-6">
+        <h2 className="font-bold mb-2">トレーニングの説明</h2>
+        <p className="whitespace-pre-line">{training.description}</p>
+      </section>
+
+      {training.instructions && (
+        <section className="mt-4 p-4 bg-gray-100 rounded-lg">
+          <h2 className="font-bold mb-2">実施方法・チェックポイント</h2>
+          <p className="whitespace-pre-line">{training.instructions}</p>
+        </section>
+      )}
+    </div>
+  );
+}
+
+

--- a/frontend/src/app/core/page.tsx
+++ b/frontend/src/app/core/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCoreTrainings } from '@/hooks/useFlexibilityChecks';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function CoreTrainingPage() {
+  const { trainings, loading, error } = useCoreTrainings();
+
+  if (error) {
+    return (
+      <div className="container mx-auto p-4">
+        <div className="text-red-500">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4">
+      <div className="flex justify-between items-center mb-8">
+        <h1 className="text-3xl font-bold">体幹トレーニング</h1>
+      </div>
+      <div className="mb-8">
+        <p className="text-gray-700 mb-4">
+          このページでは、テニス選手のパフォーマンス向上とケガ予防のための基本的な体幹トレーニングメニューを一覧で確認できます。
+        </p>
+        <p className="hidden md:block text-gray-700 mb-4">
+          各トレーニングの目的と実施時のチェックポイントを確認しながら、正しいフォームで行いましょう。
+        </p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {loading
+          ? // ローディング中のスケルトンUI
+            Array.from({ length: 6 }).map((_, index) => (
+              <Card key={index} className="w-full">
+                <CardHeader>
+                  <Skeleton className="h-6 w-3/4" />
+                </CardHeader>
+                <CardContent>
+                  <Skeleton className="h-48 w-full mb-4" />
+                  <Skeleton className="h-4 w-full" />
+                </CardContent>
+              </Card>
+            ))
+          : trainings.map((training) => (
+              <Link
+                key={training.id}
+                href={`/core/${training.id}`}
+                className="block"
+              >
+                <Card className="w-full h-full hover:shadow-lg transition-shadow">
+                  <CardHeader>
+                    <CardTitle>{training.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {training.image_path && (
+                      <div className="relative w-full h-48 mb-4">
+                        <Image
+                          src={training.image_path}
+                          alt={training.title}
+                          fill
+                          className="object-contain"
+                        />
+                      </div>
+                    )}
+                    <p className="whitespace-pre-line text-sm text-gray-700">
+                      {training.description}
+                    </p>
+                    {training.instructions && (
+                      <p className="mt-2 text-xs text-gray-500">
+                        チェックポイント: {training.instructions}
+                      </p>
+                    )}
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+      </div>
+    </div>
+  );
+}
+
+

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -64,6 +64,24 @@ const Header = () => {
               </svg>
               <span>Stretch</span>
             </Link>
+            <Link href="/core" className="flex items-center gap-2 text-gray-600 hover:text-gray-900">
+              <svg
+                className="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path d="M12 2v4" />
+                <path d="M12 18v4" />
+                <path d="M2 12h4" />
+                <path d="M18 12h4" />
+              </svg>
+              <span>Core</span>
+            </Link>
             <Link href="/about" className="flex items-center gap-2 text-gray-600 hover:text-gray-900">
               <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
               <span>About</span>
@@ -125,6 +143,24 @@ const Header = () => {
                     <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
                   </svg>
                   <span>Stretch</span>
+                </Link>
+                <Link href="/core" className="flex items-center gap-2 text-gray-600 hover:text-gray-900">
+                  <svg
+                    className="w-5 h-5"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <circle cx="12" cy="12" r="3" />
+                    <path d="M12 2v4" />
+                    <path d="M12 18v4" />
+                    <path d="M2 12h4" />
+                    <path d="M18 12h4" />
+                  </svg>
+                  <span>Core</span>
                 </Link>
               <Link href="/about" className="flex items-center gap-2 text-gray-600 hover:text-gray-900">
                 <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>

--- a/frontend/src/hooks/useFlexibilityChecks.ts
+++ b/frontend/src/hooks/useFlexibilityChecks.ts
@@ -30,7 +30,7 @@ export const useFlexibilityChecks = () => {
     fetchChecks();
   }, []);
   return { checks, loading, error };
-}; 
+};
 
 /**
  * 特定のトレーニングを取得
@@ -57,4 +57,35 @@ export const useFlexibilityCheck = (id: string) => {
     fetchCheck();
   }, [id]);
   return { check, loading, error };
-}; 
+};
+
+/**
+ * コアトレーニング一覧を取得
+ * training_type=2 (CORE) でフィルタリング
+ */
+export const useCoreTrainings = () => {
+  const [trainings, setTrainings] = useState<Training[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchTrainings = async () => {
+      try {
+        const apiBase =
+          process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+        const response = await axios.get<Training[]>(
+          `${apiBase}/trainings/?training_type=${TrainingType.CORE}`
+        );
+        setTrainings(response.data);
+        setLoading(false);
+      } catch {
+        setError('体幹トレーニングのデータの取得に失敗しました');
+        setLoading(false);
+      }
+    };
+
+    fetchTrainings();
+  }, []);
+
+  return { trainings, loading, error };
+};


### PR DESCRIPTION
## 概要
- フロントエンドにコアトレーニングページを追加
- ルーティングや関連コンポーネントを実装・調整

## 変更内容
- frontend/feature/add-coretraaingpage ブランチで実装した変更を main に取り込みます
- コアトレーニングページの表示とページ遷移を確認済み

## 確認してほしいこと
- コアトレーニングページの表示内容が想定通りか
- 既存ページへの影響がないか