### PR TITLE
Fix FastAPI routing order and add ondelete constraint to read_by FK

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -202,7 +202,7 @@ class TrainingFeedbackMessage(Base):
 
     # 既読管理
     read_at = Column(DateTime, nullable=True)
-    read_by = Column(GUID(), ForeignKey("users.id"), nullable=True)
+    read_by = Column(GUID(), ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
 
     # リレーション
     training_result = relationship(

--- a/backend/routers/trainings.py
+++ b/backend/routers/trainings.py
@@ -140,6 +140,26 @@ def create_user_training_result(
 
 
 @router.get(
+    "/user-training-results/{user_id}/{training_id}",
+    response_model=List[UserTrainingResultRead],
+)
+def read_user_training_result_by_training(
+    user_id: str, training_id: int, db: Session = Depends(get_db)
+):
+    """特定のトレーニングのユーザー結果を取得"""
+    results = (
+        db.query(models.UserTrainingResult)
+        .filter(
+            models.UserTrainingResult.user_id == user_id,
+            models.UserTrainingResult.training_id == training_id,
+        )
+        .order_by(models.UserTrainingResult.date.desc())
+        .all()
+    )
+    return results
+
+
+@router.get(
     "/user-training-results/{user_id}",
     response_model=List[UserTrainingResultWithTraining],
 )
@@ -328,26 +348,6 @@ def get_feedback_messages(
     )
 
     return messages
-
-
-@router.get(
-    "/user-training-results/{user_id}/{training_id}",
-    response_model=List[UserTrainingResultRead],
-)
-def read_user_training_result_by_training(
-    user_id: str, training_id: int, db: Session = Depends(get_db)
-):
-    """特定のトレーニングのユーザー結果を取得"""
-    results = (
-        db.query(models.UserTrainingResult)
-        .filter(
-            models.UserTrainingResult.user_id == user_id,
-            models.UserTrainingResult.training_id == training_id,
-        )
-        .order_by(models.UserTrainingResult.date.desc())
-        .all()
-    )
-    return results
 
 
 @router.post("/training-feedback-messages/", response_model=TrainingFeedbackMessageRead)


### PR DESCRIPTION
## 修正内容

このPRでは、2つの重要なバグを修正しました：

### Bug 1: FastAPIルーティング順序の修正
- **問題**: `GET /user-training-results/{user_id}/{training_id}` エンドポイントが `GET /user-training-results/{user_id}` より後に定義されていたため、より具体的なパスがマッチしなかった
- **修正**: より具体的なパス `/user-training-results/{user_id}/{training_id}` を `/user-training-results/{user_id}` より前に移動

### Bug 2: 外部キー制約の追加
- **問題**: `read_by` カラムに `ondelete` 制約がなく、ユーザー削除時にデータベース制約違反が発生する可能性があった
- **修正**: `read_by` カラムに `ondelete="SET NULL"` を追加し、ユーザー削除時に既読情報がNULLに設定されるようにした

## 変更ファイル
- `backend/routers/trainings.py`: エンドポイントの順序を修正
- `backend/models.py`: `read_by` カラムに `ondelete="SET NULL"` を追加

## テスト
- [ ] エンドポイント `/user-training-results/{user_id}/{training_id}` が正しく動作することを確認
- [ ] ユーザー削除時に既読情報が正しくNULLに設定されることを確認